### PR TITLE
New feature: pass osqp params through solver.solve method

### DIFF
--- a/sco_py/sco_osqp/osqp_utils.py
+++ b/sco_py/sco_osqp/osqp_utils.py
@@ -105,13 +105,13 @@ class OSQPLinearConstraint(object):
 # @profile
 def optimize(
     osqp_vars: List[OSQPVar],
-    sco_vars: List[Variable],
+    _sco_vars: List[Variable],
     osqp_quad_objs: List[OSQPQuadraticObj],
     osqp_lin_objs: List[OSQPLinearObj],
     osqp_lin_cnt_exprs: List[OSQPLinearConstraint],
     eps_abs: float = 1e-06,
     eps_rel: float = 1e-09,
-    max_iter: int = 10000000,
+    max_iter: int = int(1e08),
 ):
     """
     Calls the OSQP optimizer on the current QP approximation with a given

--- a/sco_py/sco_osqp/osqp_utils.py
+++ b/sco_py/sco_osqp/osqp_utils.py
@@ -109,9 +109,9 @@ def optimize(
     osqp_quad_objs: List[OSQPQuadraticObj],
     osqp_lin_objs: List[OSQPLinearObj],
     osqp_lin_cnt_exprs: List[OSQPLinearConstraint],
-    eps_abs: float = 1e-08,
+    eps_abs: float = 1e-06,
     eps_rel: float = 1e-09,
-    max_iter: int = 1000000,
+    max_iter: int = 10000000,
 ):
     """
     Calls the OSQP optimizer on the current QP approximation with a given
@@ -194,7 +194,8 @@ def optimize(
         eps_abs=eps_abs,
         eps_rel=eps_rel,
         delta=1e-07,
-        polish=True,
+        # polish=True,
+        polish=False,
         adaptive_rho=False,
         warm_start=True,
         verbose=False,

--- a/sco_py/sco_osqp/prob.py
+++ b/sco_py/sco_osqp/prob.py
@@ -143,7 +143,7 @@ class Prob(object):
 
         self.add_var(var)
 
-    def optimize(self, add_convexified_terms=False):
+    def optimize(self, add_convexified_terms=False, osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=int(1e08)):
         """
         Calls the OSQP optimizer on the current QP approximation with a given
         penalty coefficient. Note that add_convexified_terms is a convenience
@@ -157,6 +157,9 @@ class Prob(object):
                 self._osqp_quad_objs,
                 self._osqp_lin_objs,
                 self._osqp_lin_cnt_exprs,
+                osqp_eps_abs,
+                osqp_eps_rel,
+                osqp_max_iter
             )
         else:
             cnt_exprs = self._osqp_lin_cnt_exprs[:]
@@ -169,6 +172,9 @@ class Prob(object):
                 self._osqp_quad_objs,
                 self._osqp_lin_objs + self._osqp_penalty_exprs,
                 cnt_exprs,
+                osqp_eps_abs,
+                osqp_eps_rel,
+                osqp_max_iter
             )
 
         # If the solve failed, just return False

--- a/sco_py/sco_osqp/solver.py
+++ b/sco_py/sco_osqp/solver.py
@@ -25,7 +25,8 @@ class Solver(object):
         self.initial_trust_region_size = 1
         self.initial_penalty_coeff = 1e3
 
-    def solve(self, prob, method=None, tol=None, verbose=False):
+    def solve(self, prob, method=None, tol=None, verbose=False,\
+        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=int(1e08)):
         """
         Returns whether solve succeeded.
 
@@ -39,12 +40,14 @@ class Solver(object):
             self.cnt_tolerance = tol
 
         if method == "penalty_sqp":
-            return self._penalty_sqp(prob, verbose=verbose)
+            return self._penalty_sqp(prob, verbose=verbose,\
+                osqp_eps_abs=osqp_eps_abs, osqp_eps_rel=osqp_eps_rel, osqp_max_iter=osqp_max_iter)
         else:
             raise Exception("This method is not supported.")
 
     # @profile
-    def _penalty_sqp(self, prob, verbose=False):
+    def _penalty_sqp(self, prob, verbose=False,\
+        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=int(1e08)):
         """
         Return true is the penalty sqp method succeeds.
         Uses Penalty Sequential Quadratic Programming to solve the problem
@@ -59,7 +62,9 @@ class Solver(object):
 
         for i in range(self.max_merit_coeff_increases):
             success = self._min_merit_fn(
-                prob, penalty_coeff, trust_region_size, verbose=verbose
+                prob, penalty_coeff, trust_region_size, verbose=verbose,\
+                    osqp_eps_abs=osqp_eps_abs, osqp_eps_rel=osqp_eps_rel,\
+                        osqp_max_iter=osqp_max_iter
             )
             if verbose:
                 print("\n")
@@ -78,7 +83,8 @@ class Solver(object):
         return False
 
     # @profile
-    def _min_merit_fn(self, prob, penalty_coeff, trust_region_size, verbose=False):
+    def _min_merit_fn(self, prob, penalty_coeff, trust_region_size, verbose=False,\
+        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=int(1e08)):
         """
         Minimize merit function for penalty sqp.
         Returns true if the merit function is minimized successfully.
@@ -99,7 +105,8 @@ class Solver(object):
                 if verbose:
                     print(("    trust region size: {0}".format(trust_region_size)))
                 prob.add_trust_region(trust_region_size)
-                _ = prob.optimize()
+                _ = prob.optimize(osqp_eps_abs=osqp_eps_abs, osqp_eps_rel=osqp_eps_rel,\
+                        osqp_max_iter=osqp_max_iter)
                 model_merit = prob.get_approx_value(penalty_coeff)
                 model_merit_vec = prob.get_approx_value(penalty_coeff, True)
                 new_merit = prob.get_value(penalty_coeff)


### PR DESCRIPTION
This enables users to call `solver.solve()` with different osqp parameters instead of having to manually tune them inside `osqp_utils.py`