### PR TITLE
Switch OSQP to not crash if max_iter reached & lowered default max_iter

### DIFF
--- a/sco_py/sco_osqp/osqp_utils.py
+++ b/sco_py/sco_osqp/osqp_utils.py
@@ -7,7 +7,7 @@ import scipy
 from sco_py.sco_osqp.variable import Variable
 
 
-DEFAULT_MAX_ITER = 100
+DEFAULT_MAX_ITER = int(1e04)
 
 class OSQPVar(object):
     """

--- a/sco_py/sco_osqp/osqp_utils.py
+++ b/sco_py/sco_osqp/osqp_utils.py
@@ -112,6 +112,7 @@ def optimize(
     eps_abs: float = 1e-06,
     eps_rel: float = 1e-09,
     max_iter: int = int(1e08),
+    verbose: bool = False,
 ):
     """
     Calls the OSQP optimizer on the current QP approximation with a given
@@ -204,8 +205,8 @@ def optimize(
 
     solve_res = m.solve()
 
-    if solve_res.info.status_val == -2:
-        raise RuntimeError("ERROR! OSQP Solver hit max iteration limit. Either reduce your tolerances or increase the max iterations!")
+    if solve_res.info.status_val == -2 and verbose:
+        print("ERROR! OSQP Solver hit max iteration limit. Either reduce your tolerances or increase the max iterations!")
 
     return (solve_res, var_to_index_dict)
 

--- a/sco_py/sco_osqp/osqp_utils.py
+++ b/sco_py/sco_osqp/osqp_utils.py
@@ -7,7 +7,7 @@ import scipy
 from sco_py.sco_osqp.variable import Variable
 
 
-DEFAULT_MAX_ITER = int(1e04)
+DEFAULT_MAX_ITER = int(1e05)
 
 class OSQPVar(object):
     """

--- a/sco_py/sco_osqp/osqp_utils.py
+++ b/sco_py/sco_osqp/osqp_utils.py
@@ -7,6 +7,8 @@ import scipy
 from sco_py.sco_osqp.variable import Variable
 
 
+DEFAULT_MAX_ITER = 100
+
 class OSQPVar(object):
     """
     A class representing a variable within OSQP that will be used to construct the

--- a/sco_py/sco_osqp/prob.py
+++ b/sco_py/sco_osqp/prob.py
@@ -143,7 +143,12 @@ class Prob(object):
 
         self.add_var(var)
 
-    def optimize(self, add_convexified_terms=False, osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=int(1e08)):
+    def optimize(self, 
+                 add_convexified_terms=False, 
+                 osqp_eps_abs=1e-06, 
+                 osqp_eps_rel=1e-09, 
+                 osqp_max_iter=osqp_utils.DEFAULT_MAX_ITER, 
+                 verbose=False):
         """
         Calls the OSQP optimizer on the current QP approximation with a given
         penalty coefficient. Note that add_convexified_terms is a convenience
@@ -159,7 +164,8 @@ class Prob(object):
                 self._osqp_lin_cnt_exprs,
                 osqp_eps_abs,
                 osqp_eps_rel,
-                osqp_max_iter
+                osqp_max_iter,
+                verbose=verbose,
             )
         else:
             cnt_exprs = self._osqp_lin_cnt_exprs[:]
@@ -174,7 +180,8 @@ class Prob(object):
                 cnt_exprs,
                 osqp_eps_abs,
                 osqp_eps_rel,
-                osqp_max_iter
+                osqp_max_iter,
+                verbose=verbose,
             )
 
         # If the solve failed, just return False

--- a/sco_py/sco_osqp/solver.py
+++ b/sco_py/sco_osqp/solver.py
@@ -3,6 +3,8 @@ import time
 import numpy as np
 
 
+DEFAULT_MAX_ITER = 100
+
 class Solver(object):
     """
     SCO Solver
@@ -26,7 +28,7 @@ class Solver(object):
         self.initial_penalty_coeff = 1e3
 
     def solve(self, prob, method=None, tol=None, verbose=False,\
-        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=int(1e08)):
+        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=DEFAULT_MAX_ITER):
         """
         Returns whether solve succeeded.
 
@@ -47,7 +49,7 @@ class Solver(object):
 
     # @profile
     def _penalty_sqp(self, prob, verbose=False,\
-        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=int(1e08)):
+        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=DEFAULT_MAX_ITER):
         """
         Return true is the penalty sqp method succeeds.
         Uses Penalty Sequential Quadratic Programming to solve the problem
@@ -84,7 +86,7 @@ class Solver(object):
 
     # @profile
     def _min_merit_fn(self, prob, penalty_coeff, trust_region_size, verbose=False,\
-        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=int(1e08)):
+        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=DEFAULT_MAX_ITER):
         """
         Minimize merit function for penalty sqp.
         Returns true if the merit function is minimized successfully.
@@ -105,8 +107,10 @@ class Solver(object):
                 if verbose:
                     print(("    trust region size: {0}".format(trust_region_size)))
                 prob.add_trust_region(trust_region_size)
-                _ = prob.optimize(osqp_eps_abs=osqp_eps_abs, osqp_eps_rel=osqp_eps_rel,\
-                        osqp_max_iter=osqp_max_iter)
+                _ = prob.optimize(osqp_eps_abs=osqp_eps_abs, 
+                                  osqp_eps_rel=osqp_eps_rel,\
+                                  osqp_max_iter=osqp_max_iter,
+                                  verbose=verbose)
                 model_merit = prob.get_approx_value(penalty_coeff)
                 model_merit_vec = prob.get_approx_value(penalty_coeff, True)
                 new_merit = prob.get_value(penalty_coeff)

--- a/sco_py/sco_osqp/solver.py
+++ b/sco_py/sco_osqp/solver.py
@@ -2,8 +2,8 @@ import time
 
 import numpy as np
 
+import sco_py.sco_osqp.osqp_utils as osqp_utils
 
-DEFAULT_MAX_ITER = 100
 
 class Solver(object):
     """
@@ -27,8 +27,14 @@ class Solver(object):
         self.initial_trust_region_size = 1
         self.initial_penalty_coeff = 1e3
 
-    def solve(self, prob, method=None, tol=None, verbose=False,\
-        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=DEFAULT_MAX_ITER):
+    def solve(self, 
+              prob, 
+              method=None, 
+              tol=None, 
+              verbose=False,
+              osqp_eps_abs=1e-06, 
+              osqp_eps_rel=1e-09, 
+              osqp_max_iter=osqp_utils.DEFAULT_MAX_ITER):
         """
         Returns whether solve succeeded.
 
@@ -48,8 +54,12 @@ class Solver(object):
             raise Exception("This method is not supported.")
 
     # @profile
-    def _penalty_sqp(self, prob, verbose=False,\
-        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=DEFAULT_MAX_ITER):
+    def _penalty_sqp(self, 
+                     prob, 
+                     verbose=False,
+                     osqp_eps_abs=2e-06, 
+                     osqp_eps_rel=1e-09, 
+                     osqp_max_iter=osqp_utils.DEFAULT_MAX_ITER):
         """
         Return true is the penalty sqp method succeeds.
         Uses Penalty Sequential Quadratic Programming to solve the problem
@@ -86,7 +96,7 @@ class Solver(object):
 
     # @profile
     def _min_merit_fn(self, prob, penalty_coeff, trust_region_size, verbose=False,\
-        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=DEFAULT_MAX_ITER):
+        osqp_eps_abs=1e-06, osqp_eps_rel=1e-09, osqp_max_iter=osqp_utils.DEFAULT_MAX_ITER):
         """
         Minimize merit function for penalty sqp.
         Returns true if the merit function is minimized successfully.


### PR DESCRIPTION
We want OSQP to be able to reach max_iter without erroring; failure to optimize should be verified but the end user (e.g. TAMP) should decide if that's worth crashing on or not (e.g., TAMP uses this as the signal to invoke resampling and possibly backtracking). We also want max_iter to be a lot lower by default (around 100). More than this just means it's going to take longer to reach max_iter.